### PR TITLE
Energy constant H0

### DIFF
--- a/Fortran90/data_types/commons.f90
+++ b/Fortran90/data_types/commons.f90
@@ -3,7 +3,7 @@
         real*8, parameter :: hads=-1.171955613174250d0 
         real*8, parameter :: jint=0.3d0
         real*8, parameter :: kb=8.6173303d-5
-        real*8 chemp, temp
+        real*8 chemp, temp, h0
 
     
         end module commons

--- a/Fortran90/data_types/funcv.f90
+++ b/Fortran90/data_types/funcv.f90
@@ -1,5 +1,6 @@
 	subroutine funcv(fvec)
         use commons
+        use meso_approx
         use approx_inst
 	implicit none
         integer i, j, total

--- a/Fortran90/data_types/main.f90
+++ b/Fortran90/data_types/main.f90
@@ -44,6 +44,6 @@
          end do
          cov=cov/nsites
          write(16,*) chemp, cov, obj_approx%part()
-         h0=-kb*temp*log(obj_approx%part())
+         h0=h0+kb*temp*log(obj_approx%part())
         end do
         end program 

--- a/Fortran90/data_types/main.f90
+++ b/Fortran90/data_types/main.f90
@@ -33,6 +33,7 @@
 
         ! Coverage vs Chemical Potential Plot
         chemp=-1.40d0
+        h0=0.d0
         do i=1,240
          chemp=chemp+0.01d0
          call solver(obj_approx%hamilt%corr%value,npar,check)
@@ -43,5 +44,6 @@
          end do
          cov=cov/nsites
          write(16,*) chemp, cov
+         h0=-kb*temp*log(obj_approx%part())
         end do
         end program 

--- a/Fortran90/data_types/main.f90
+++ b/Fortran90/data_types/main.f90
@@ -43,7 +43,7 @@
           cov=cov+obj_approx%corfun(v,1,obj_approx)/obj_approx%part()
          end do
          cov=cov/nsites
-         write(16,*) chemp, cov
+         write(16,*) chemp, cov, obj_approx%part()
          h0=-kb*temp*log(obj_approx%part())
         end do
         end program 

--- a/Fortran90/data_types/meso_approx.f90
+++ b/Fortran90/data_types/meso_approx.f90
@@ -81,8 +81,9 @@
     partition=0.d0
     do i=1,2**nsites
      call confs(state,i)
-     partition=partition+exp((chemp*sum(state)-appr%ener(appr,state))/(kb*temp))
+     partition=partition+exp((chemp*sum(state)-appr%ener(appr,state)-h0)/(kb*temp))
     end do
+    partition=partition*exp(h0/(kb*temp))
     end function
  
     real*8 function correlation(v,m,appr)
@@ -102,8 +103,9 @@
      do k=1,m
       s=s*state(v(k))
      end do
-     correlation=correlation+s*exp((chemp*sum(state)-appr%ener(appr,state))/(kb*temp))
+     correlation=correlation+s*exp((chemp*sum(state)-appr%ener(appr,state)-h0)/(kb*temp))
     end do
+    correlation=correlation*exp(h0/(kb*temp))
     end function
  
     subroutine approx_initialisation(appr)

--- a/Fortran90/data_types/meso_approx.f90
+++ b/Fortran90/data_types/meso_approx.f90
@@ -83,7 +83,6 @@
      call confs(state,i)
      partition=partition+exp((chemp*sum(state)-appr%ener(appr,state)-h0)/(kb*temp))
     end do
-    partition=partition*exp(h0/(kb*temp))
     end function
  
     real*8 function correlation(v,m,appr)
@@ -105,7 +104,6 @@
      end do
      correlation=correlation+s*exp((chemp*sum(state)-appr%ener(appr,state)-h0)/(kb*temp))
     end do
-    correlation=correlation*exp(h0/(kb*temp))
     end function
  
     subroutine approx_initialisation(appr)

--- a/Fortran90/data_types/plotresults.m
+++ b/Fortran90/data_types/plotresults.m
@@ -1,0 +1,7 @@
+clear all
+clc
+figure
+
+Q = load('fort.16');
+plot(Q(:,1),Q(:,2))
+


### PR DESCRIPTION
In the calculation of partition function sums and the like, we need to avoid the overflow errors created by large terms. This is done by redefining the reference energy h0 as the chemical potential increases.