### PR TITLE
Travis-wait for testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,11 +65,11 @@ script:
   - cd FortranCode
   - mkdir build
   - cd build
-  - travis_wait 30 cmake .. -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -Ddoopenmp=OFF
+  - cmake .. -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -Ddoopenmp=OFF
   - make -j
   # - ctest --output-on-failure
   # - ctest -L fast --output-on-failure
-  - ctest -L "(fast|medium)" --output-on-failure
+  - travis_wait 30 ctest -L "(fast|medium)" --output-on-failure
 
 after_script:
   - find . -name "uninstal*"

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,8 +68,8 @@ script:
   - travis_wait 30 cmake .. -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -Ddoopenmp=OFF
   - make -j
   # - ctest --output-on-failure
-  - ctest -L fast --output-on-failure
-  # - ctest -L "(fast|medium)" --output-on-failure
+  # - ctest -L fast --output-on-failure
+  - ctest -L "(fast|medium)" --output-on-failure
 
 after_script:
   - find . -name "uninstal*"

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,15 +65,11 @@ script:
   - cd FortranCode
   - mkdir build
   - cd build
-  - cmake .. -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -Ddoopenmp=OFF
+  - travis_wait 30 cmake .. -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -Ddoopenmp=OFF
   - make -j
-  - while sleep 540 ; do echo "=========== tests are taking more than 9m - pinging travis =========="; done &
-  - PING_PID=$!
   # - ctest --output-on-failure
   - ctest -L fast --output-on-failure
   # - ctest -L "(fast|medium)" --output-on-failure
-  # The following kills the pinging process, otherwise Windows builds hang
-  - kill $PING_PID
 
 after_script:
   - find . -name "uninstal*"


### PR DESCRIPTION
This replaces the ping command we previously had, which keeps Travis "alive" when long tests are run.