### PR TITLE
Cleaned up the profiling branch

### DIFF
--- a/FortranCode/meso_approx.f90
+++ b/FortranCode/meso_approx.f90
@@ -362,7 +362,8 @@ module meso_approx
 !        this%eqns%jacobian = -1/(kboltz*this%temp)*this%eqns%jacobian
 
         loop_step = min(upper_range, 4096)
-        !$OMP PARALLEL DO
+        !$OMP PARALLEL DO PRIVATE(lhs_i, rhs_i, tmp_var3, tmp_var4, lhsderivativeterm, rhsderivativeterm, &
+                                  tmp_id, i, j, k, kk)
         do i = 1,this%eqns%neqns
             lhs_i = (this%eqns%lhs(i) - 1) * upper_range
             rhs_i = (this%eqns%rhs(i) - 1) * upper_range

--- a/FortranCode/meso_approx.f90
+++ b/FortranCode/meso_approx.f90
@@ -11,9 +11,11 @@ module meso_approx
 		integer, allocatable, dimension(:,:) :: interaction ! intended as a (nterms x nbodymax) array encoding interaction terms e.g. 1, 2, 1-2, ...
 		integer, allocatable, dimension(:) :: origterms ! integers pointing to origpars (see below) to return original Hamiltonian parameters for each of the interaction terms in vector "interaction" above
 		integer, allocatable, dimension(:) :: corcterms ! integers pointing to corcpars (see below) to return correction parameters for each of the interaction terms in vector "interaction" above
-		integer, allocatable, dimension(:,:) :: stateprods ! array storing terms that appear in the Hamiltonian, like sigma(1)*sigma(2) etc, for each state.
-		integer, allocatable, dimension(:,:) :: sumstateprodsorig ! array storing sums of the above, which make it faster to calculate dHamiltonian/dcorcpar, for each state.
-		integer, allocatable, dimension(:,:) :: sumstateprodscorc ! array storing sums of the above, which make it faster to calculate dHamiltonian/dcorcpar, for each state.
+		integer, allocatable, dimension(:) :: stateprods ! array storing terms that appear in the Hamiltonian, like sigma(1)*sigma(2) etc, for each state.
+		integer, allocatable, dimension(:) :: sumstateprodsorig ! array storing sums of the above, which make it faster to calculate dHamiltonian/dcorcpar, for each state.
+        integer, allocatable, dimension(:) :: sumstateprodscorc ! array storing sums of the above, which make it faster to calculate dHamiltonian/dcorcpar, for each state.
+        integer, allocatable, dimension(:) :: time_saver_lhs(:) ! these are just two auxiliary arrays that store pre-calculated values
+        integer, allocatable, dimension(:) :: time_saver_rhs(:) ! that are usually evaluated on every iteration
         ! All three of the above are stored as members of the class for computational efficiency, but for large approximations it can be memory intensive!
         
 		integer norig      ! number of original parameters in the Hamiltonian, e.g. = 2 if only adsorption energy and 1NN interaction energy are used
@@ -46,7 +48,7 @@ module meso_approx
 		integer, allocatable, dimension(:) :: rhs  ! points to array "correlation", encoding the right hand side of each equation
 		real(8), allocatable, dimension(:) :: residual  ! residual of each equation
 		real(8), allocatable, dimension(:,:) :: jacobian  ! jacobian of each equation
-        integer, allocatable, dimension(:,:) ::  stateprods(:,:) ! array storing terms that appear in the correlations, like sigma(1)*sigma(2) etc, for each state.
+        integer, allocatable, dimension(:) ::  stateprods(:) ! array storing terms that appear in the correlations, like sigma(1)*sigma(2) etc, for each state.
         ! These are saved for computational efficiency, but for large approximations it can be memory intensive!
         
 		! The sizes of the above are intended to be:
@@ -149,34 +151,76 @@ module meso_approx
     
         implicit none
         class (approximation) :: this
-        integer i, j
+        integer i, j, k, upper_range, tmp_int
+        real(8) tmp_val
+        logical is_even_ncorc
+        upper_range = 2**this%nsites
         
         ! Preparatory steps: allocate and precompute stateprods, sumstateprodsorig, sumstateprodscorc
         if (.not. (allocated(this%hamilt%sumstateprodsorig) .and. allocated(this%hamilt%sumstateprodscorc))) then 
             if (.not. allocated(this%hamilt%stateprods)) then
-                allocate(this%hamilt%stateprods(2**this%nsites,this%hamilt%nterms),source=1)
+                allocate(this%hamilt%stateprods(upper_range * this%hamilt%nterms),source=1)
                 do i = 1,this%hamilt%nterms
                     do j = 1,this%hamilt%internbody(i)
-                        this%hamilt%stateprods(:,i) = &
-                            this%hamilt%stateprods(:,i)*this%allstates(:,this%hamilt%interaction(i,j))
+                        do k = 1, upper_range
+                            tmp_int = k + (i - 1) * upper_range
+                            this%hamilt%stateprods(tmp_int) = &
+                                        this%hamilt%stateprods(tmp_int) * this%allstates(k, this%hamilt%interaction(i,j))
+                        enddo
                     enddo
                 enddo
             endif
             if (.not. allocated(this%hamilt%sumstateprodsorig)) then
-                allocate(this%hamilt%sumstateprodsorig(2**this%nsites,this%hamilt%norig),source=0)
-                do i = 1,2**this%nsites
+                allocate(this%hamilt%sumstateprodsorig(upper_range * this%hamilt%norig),source=0)
+                do i = 1,upper_range
                     do j = 1,this%hamilt%norig
-                        this%hamilt%sumstateprodsorig(i,j) = sum(this%hamilt%stateprods(i,:),MASK=this%hamilt%origterms(1:)==j)
+                        tmp_int = 0
+                        do k = 1, this%hamilt%nterms
+                            if (this%hamilt%origterms(k) .eq. j) &
+                                tmp_int = tmp_int + this%hamilt%stateprods(i + (k - 1) * upper_range)
+                        enddo
+                        this%hamilt%sumstateprodsorig(i + (j - 1) * upper_range) = tmp_int
                     enddo
                 enddo
             endif
             if (.not. allocated(this%hamilt%sumstateprodscorc)) then
-                allocate(this%hamilt%sumstateprodscorc(2**this%nsites,this%hamilt%ncorc),source=0)
-                do i = 1,2**this%nsites
+                allocate(this%hamilt%sumstateprodscorc(upper_range * this%hamilt%ncorc), source=0)
+                do i = 1,upper_range
                     do j = 1,this%hamilt%ncorc
-                        this%hamilt%sumstateprodscorc(i,j) = sum(this%hamilt%stateprods(i,:),MASK=this%hamilt%corcterms(1:)==j)
+                        tmp_int = 0
+                        do k = 1, this%hamilt%nterms
+                            if (this%hamilt%corcterms(k) .eq. j) &
+                                tmp_int = tmp_int + this%hamilt%stateprods(i + (k - 1) * upper_range)
+                        enddo
+                        this%hamilt%sumstateprodscorc(i + (j - 1) * upper_range) = tmp_int
                     enddo
                 enddo
+                !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+                ! Compute time_saver
+                allocate(this%hamilt%time_saver_lhs(upper_range * this%eqns%neqns * this%eqns%neqns), source=0)
+                allocate(this%hamilt%time_saver_rhs(upper_range * this%eqns%neqns * this%eqns%neqns), source=0)
+                do i = 1,this%eqns%neqns
+                    do j = 1,this%eqns%neqns
+                        tmp_int = upper_range * (j - 1 + this%eqns%neqns * (i - 1))
+                        do k = 1, upper_range, 2
+                            this%hamilt%time_saver_lhs(k + tmp_int) = &
+                                                                this%eqns%stateprods(k + (this%eqns%lhs(i) - 1) * upper_range) &
+                                                              * this%hamilt%sumstateprodscorc(k + (j - 1) * upper_range)
+                            this%hamilt%time_saver_lhs(k + 1 + tmp_int) = &
+                                                              this%eqns%stateprods(k + 1 + (this%eqns%lhs(i) - 1) * upper_range) &
+                                                            * this%hamilt%sumstateprodscorc(k + 1 + (j - 1) * upper_range)
+        
+                            this%hamilt%time_saver_rhs(k + tmp_int) = &
+                                                                this%eqns%stateprods(k + (this%eqns%rhs(i) - 1) * upper_range) &
+                                                              * this%hamilt%sumstateprodscorc(k + (j - 1) * upper_range)
+                                                              
+                            this%hamilt%time_saver_rhs(k + 1 + tmp_int) = &
+                                                              this%eqns%stateprods(k + 1 + (this%eqns%rhs(i) - 1) * upper_range) &
+                                                            * this%hamilt%sumstateprodscorc(k + 1 + (j - 1) * upper_range)
+                        enddo
+                    enddo
+                enddo
+                !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
             endif
             deallocate(this%hamilt%stateprods) ! free up some memory; this array not needed anymore, unless we use the first method to calculate energies
         endif
@@ -192,18 +236,20 @@ module meso_approx
         
         this%allenergs = this%hamilt%H0
         do i = 1,this%hamilt%norig
-            do j = 1,2**this%nsites
-                this%allenergs(j) = this%allenergs(j) + & 
-                    this%hamilt%origpars(i)*this%hamilt%sumstateprodsorig(j,i)
+            tmp_val = this%hamilt%origpars(i)
+            do j = 1,upper_range
+                this%allenergs(j) = this%allenergs(j) + &
+                    tmp_val*this%hamilt%sumstateprodsorig(j + (i - 1) * upper_range)
             enddo
         enddo
         do i = 1,this%hamilt%ncorc
-            do j = 1,2**this%nsites
-                this%allenergs(j) = this%allenergs(j) + & 
-                    this%hamilt%corcpars(i)*this%hamilt%sumstateprodscorc(j,i)
+            tmp_val = this%hamilt%corcpars(i)
+            do j = 1,upper_range
+                this%allenergs(j) = this%allenergs(j) + &
+                    tmp_val * this%hamilt%sumstateprodscorc(j + (i - 1) * upper_range)
             enddo
         enddo
-
+        
         return
         
     end subroutine calculate_energies
@@ -216,10 +262,16 @@ module meso_approx
         implicit none
         
         class (approximation) :: this
-        integer i, j, k
+!        integer i, j, k
+        integer i, j, k, kk, upper_range
         real(8) lhsderivativeterm, rhsderivativeterm
         logical, intent(in), optional :: calcjac
         logical :: calculatejacobian
+        integer lhs_i, rhs_i, id, tmp_id
+        real(8) tmp_var1, tmp_var2, tmp_var3, tmp_var4
+        integer loop_step
+
+        upper_range = 2**this%nsites
         
         if (present(calcjac)) then
             calculatejacobian = calcjac
@@ -229,37 +281,67 @@ module meso_approx
         
         ! Preparatory steps: allocate and precompute stateprods
         if (.not. allocated(this%eqns%stateprods)) then
-            allocate(this%eqns%stateprods(2**this%nsites,this%eqns%nterms),source=1)
+!            allocate(this%eqns%stateprods(2**this%nsites,this%eqns%nterms),source=1)
+!            do i = 1,this%eqns%nterms
+!                do j = 1,this%eqns%corrlnbody(i)
+!                    this%eqns%stateprods(:,i) = &
+!                        this%eqns%stateprods(:,i)*this%allstates(:,this%eqns%correlation(i,j))
+!                enddo
+!            enddo
+            allocate(this%eqns%stateprods(upper_range * this%eqns%nterms), source = 1)
             do i = 1,this%eqns%nterms
                 do j = 1,this%eqns%corrlnbody(i)
-                    this%eqns%stateprods(:,i) = &
-                        this%eqns%stateprods(:,i)*this%allstates(:,this%eqns%correlation(i,j))
+                    tmp_id = this%eqns%correlation(i, j)
+                    do k = 1, upper_range
+                        id = k + (i - 1) * upper_range
+                        this%eqns%stateprods(id) = &
+                            this%eqns%stateprods(id) * this%allstates(k, tmp_id)
+                    enddo
                 enddo
             enddo
         endif
         if (.not. allocated(this%expenergies)) then
-            allocate(this%expenergies(2**this%nsites),source=0.d0)
+!            allocate(this%expenergies(2**this%nsites),source=0.d0)
+            allocate(this%expenergies(upper_range),source=0.d0)
         endif
 
         call this%calc_energ() ! Note that we calculate the energies here, so if a program unit is calling the correlations subroutine,
         ! it would be unnecessary (and a waste of time) to compute the energies in the calling program unit
-        this%expenergies = exp(-(this%allenergs-this%mu*this%nparticles)/(kboltz*this%temp))
+!        this%expenergies = exp(-(this%allenergs-this%mu*this%nparticles)/(kboltz*this%temp))
+        do i = 1, upper_range
+            this%expenergies(i) = exp(-(this%allenergs(i) - this%mu * this%nparticles(i)) / (kboltz*this%temp))
+        enddo
         
         this%eqns%corrlvalue = 0.d0
 
-        this%partfcn = sum(this%expenergies)
+!        this%partfcn = sum(this%expenergies)
+        this%partfcn = 0.d0
+        do i = 1,upper_range
+            this%partfcn = this%partfcn + this%expenergies(i)
+        enddo
+
         do i = 1,this%eqns%nterms
             ! The following two expressions should give the same results (numerical accuracy issues excluded)
             ! In the Matlab code the first expression is used, i.e. not the actual correlation function, but the 
             ! non-normalised partial sum that corresponds to that correlation
-            this%eqns%corrlvalue(i) = sum(this%eqns%stateprods(:,i)*this%expenergies)
+!            this%eqns%corrlvalue(i) = sum(this%eqns%stateprods(:,i)*this%expenergies)
+            tmp_var1 = 0.d0
+            do k = 1,upper_range,1
+                ! tmp_var1 = tmp_var1 &
+                !                     + this%eqns%stateprods(k,i) * this%expenergies(k)
+                tmp_var1 = tmp_var1 &
+                                    + this%eqns%stateprods(k + (i - 1) * upper_range) &
+                                    * this%expenergies(k)
+            enddo
+            this%eqns%corrlvalue(i) = tmp_var1
             ! this%eqns%corrlvalue(i) = sum(this%eqns%stateprods(:,i)*this%expenergies)/this%partfcn
         enddo        
     
         this%eqns%residual = 0.d0
         do i = 1,this%eqns%neqns
             ! Again, two options. In Matlab we have used the version of the equations with the logarithms
-            this%eqns%residual(i) = log(this%eqns%corrlvalue(this%eqns%lhs(i))) - log(this%eqns%corrlvalue(this%eqns%rhs(i)))
+!            this%eqns%residual(i) = log(this%eqns%corrlvalue(this%eqns%lhs(i))) - log(this%eqns%corrlvalue(this%eqns%rhs(i)))
+            this%eqns%residual(i) = log(this%eqns%corrlvalue(this%eqns%lhs(i))) - log(this%eqns%corrlvalue(this%eqns%rhs(i)))    ! One log is better than two
             ! this%eqns%residual(i) = this%eqns%corrlvalue(this%eqns%lhs(i)) - this%eqns%corrlvalue(this%eqns%rhs(i))
         enddo
         
@@ -267,17 +349,55 @@ module meso_approx
         
         if (.not.calculatejacobian) return
         
+!        do i = 1,this%eqns%neqns
+!            do j = 1,this%eqns%neqns
+!                lhsderivativeterm = sum(this%eqns%stateprods(:,this%eqns%lhs(i)) &
+!                                        *this%expenergies*this%hamilt%sumstateprodscorc(:,j))
+!                rhsderivativeterm = sum(this%eqns%stateprods(:,this%eqns%rhs(i)) &
+!                                        *this%expenergies*this%hamilt%sumstateprodscorc(:,j))
+!                this%eqns%jacobian(i,j) = 1.d0/this%eqns%corrlvalue(this%eqns%lhs(i))*lhsderivativeterm &
+!                    - 1.d0/this%eqns%corrlvalue(this%eqns%rhs(i))*rhsderivativeterm
+!            enddo
+!        enddo
+!        this%eqns%jacobian = -1/(kboltz*this%temp)*this%eqns%jacobian
+
+        loop_step = min(upper_range, 4096)
+        !$OMP PARALLEL DO
         do i = 1,this%eqns%neqns
+            lhs_i = (this%eqns%lhs(i) - 1) * upper_range
+            rhs_i = (this%eqns%rhs(i) - 1) * upper_range
+            
+            tmp_var3 = 1.d0/this%eqns%corrlvalue(this%eqns%lhs(i))
+            tmp_var4 = 1.d0/this%eqns%corrlvalue(this%eqns%rhs(i))
             do j = 1,this%eqns%neqns
-                lhsderivativeterm = sum(this%eqns%stateprods(:,this%eqns%lhs(i)) &
-                                        *this%expenergies*this%hamilt%sumstateprodscorc(:,j))
-                rhsderivativeterm = sum(this%eqns%stateprods(:,this%eqns%rhs(i)) &
-                                        *this%expenergies*this%hamilt%sumstateprodscorc(:,j))
-                this%eqns%jacobian(i,j) = 1.d0/this%eqns%corrlvalue(this%eqns%lhs(i))*lhsderivativeterm &
-                    - 1.d0/this%eqns%corrlvalue(this%eqns%rhs(i))*rhsderivativeterm
+                lhsderivativeterm = 0.d0
+                rhsderivativeterm = 0.d0
+                tmp_id = upper_range * (j - 1 + this%eqns%neqns * (i - 1))
+                do k = 1, upper_range, loop_step
+                    do kk = k, k + loop_step - 1, 2
+                        lhsderivativeterm = lhsderivativeterm &
+                                          + this%hamilt%time_saver_lhs(kk + tmp_id) &
+                                          * this%expenergies(kk) &
+                                          + this%hamilt%time_saver_lhs(kk + tmp_id + 1) &
+                                          * this%expenergies(kk + 1)
+                        rhsderivativeterm = rhsderivativeterm &
+                                          + this%hamilt%time_saver_rhs(kk + tmp_id) &
+                                          * this%expenergies(kk) &
+                                          + this%hamilt%time_saver_rhs(kk + tmp_id + 1) &
+                                          * this%expenergies(kk + 1)
+                    enddo
+                enddo
+                this%eqns%jacobian(i,j) = tmp_var3 * lhsderivativeterm &
+                                        - tmp_var4 * rhsderivativeterm
             enddo
         enddo
-        this%eqns%jacobian = -1/(kboltz*this%temp)*this%eqns%jacobian
+        !$OMP END PARALLEL DO
+
+        do j = 1,this%eqns%neqns
+            do i = 1,this%eqns%neqns
+                this%eqns%jacobian(i, j) = -1.d0/(kboltz*this%temp)*this%eqns%jacobian(i, j)
+            enddo
+        enddo
 
         return
     


### PR DESCRIPTION
## About
This is the cleaned/working version of the `profiling` branch. In this version:
1) almost all 2d arrays are replaced by 1d arrays;
2) reduced cache misses
3) added OMP parallelization to the most expensive loop in the `calculate_residuals` subroutine

## Comparison with master branch
### Hardware
Haswell nodes: Intel(R) Xeon(R) CPU E5-2690 v3 @ 2.60GHz, 64GB RAM

### Compiler flags
Intel: `ifort 18.0.3 20180410`; `-O3 -xAVX2 -qopenmp`
GNU: `gfortran 7.3.0`; `-O3 -mavx2 -fopenmp`

### Execution time
Executioon time of the code is reported in seconds:
Intel | master | clean_profiling |
-- | -- | -- |
BPEC | 0.015 | 0.016 |
K2NNC2 | 0.160 | 0.187 |
K3NNC2 | 30.893 | 28.345 |

GNU | master | clean_profiling
-- | -- | --
BPEC | 0.017 | 0.017
K2NNC2 | 0.546 | 0.452
K3NNC2 | 66.635 | 50.019

### OpenMP scaling
Execution time is reported in seconds for `K3NNC2` case. Environment variables are set to:
```bahs
OMP_PROC_BIND=spread
OMP_PLACES=cores
```

Compiler | Intel | GNU
-- | -- | --
1 thread | 28.113 | 49.898
4 threads | 13.632 | 27.146
12 threads | 9.939 | 21.100



